### PR TITLE
Add waitUntilCompleted() to Metal and OpenGL graphic APIs

### DIFF
--- a/src/GraphicAPI/Metal/MetalGraphicAPI.mm
+++ b/src/GraphicAPI/Metal/MetalGraphicAPI.mm
@@ -263,6 +263,7 @@ void MetalGraphicAPI::endFrame()
         m_window->clearCurrentDrawables();
     }
     [m_commandBuffer commit];
+    [m_commandBuffer waitUntilCompleted];
     [m_commandBuffer release];
 }
 

--- a/src/GraphicAPI/OpenGL/OpenGLGraphicAPI.cpp
+++ b/src/GraphicAPI/OpenGL/OpenGLGraphicAPI.cpp
@@ -285,6 +285,7 @@ void OpenGLGraphicAPI::endFrame()
     }
     #endif
 
+    GL_CALL(glFinish());
     m_window->swapBuffer();
 }
 


### PR DESCRIPTION
This pull request adds the `waitUntilCompleted()` method to the Metal and OpenGL graphic APIs. The `waitUntilCompleted()` method ensures that the command buffer is completed before continuing execution. Additionally, the pull request includes a fix in the OpenGL graphic API to call `glFinish()` before swapping buffers to ensure that all OpenGL commands are executed before presenting the frame.