### PR TITLE
Gate Tracy GPU profiling by build config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,10 @@ if (GFX_BUILD_TRACY)
         GIT_SHALLOW    1
         GIT_PROGRESS   TRUE
     )
-    set(TRACY_LTO ON)
+    set(TRACY_ENABLE OFF)
+    set(TRACY_LTO     ON)
     FetchContent_MakeAvailable(tracy)
+    target_compile_definitions(TracyClient PUBLIC "$<$<NOT:$<CONFIG:Release>>:TRACY_ENABLE>")
     if(NOT MSVC)
         target_compile_options(TracyClient PRIVATE -Wno-deprecated-declarations)
     endif()

--- a/src/Metal/MetalDevice.hpp
+++ b/src/Metal/MetalDevice.hpp
@@ -68,7 +68,7 @@ public:
     ~MetalDevice() override;
 
 public:
-    inline static tracy::MetalCtx* s_tracyMtlContext = nullptr;
+    inline static TracyMetalCtx* s_tracyMtlContext = nullptr;
 
 private:
     id<MTLDevice> m_mtlDevice = nil;

--- a/src/Metal/MetalParameterBlock.mm
+++ b/src/Metal/MetalParameterBlock.mm
@@ -29,11 +29,13 @@ uint32_t bindingOffset(const gfx::ParameterBlockLayout& layout, uint32_t idx)
     return std::accumulate(bindingCounts.begin(), std::next(bindingCounts.begin(), idx), 0u);
 }
 
+#ifndef NDEBUG
 uint32_t totalDescriptorCount(const gfx::ParameterBlockLayout& layout)
 {
     const auto bindingCounts = layout.bindings() | std::views::transform([](const auto& binding) { return binding.count; });
     return std::accumulate(bindingCounts.begin(), bindingCounts.end(), 0u);
 }
+#endif
 
 }
 

--- a/src/Vulkan/VulkanDevice.hpp
+++ b/src/Vulkan/VulkanDevice.hpp
@@ -78,7 +78,7 @@ public:
     ~VulkanDevice() override;
 
 public:
-    inline static tracy::VkCtx* s_tracyVkContext = nullptr;
+    inline static TracyVkCtx s_tracyVkContext = nullptr;
 
 private:
     const VulkanInstance* const m_instance = nullptr;

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -106,32 +106,42 @@ struct GLFWwindow;
     #define ZoneScopedN(x)
 #endif
 
-#if defined(GFX_BUILD_TRACY) && defined(GFX_BUILD_METAL) && defined(__OBJC__) && (defined(__aarch64__) || defined(__arm64__))
-    #include <tracy/TracyMetal.hmm>
-#else
-    #define TracyMetalContext(device) nullptr
-    #define TracyMetalDestroy(ctx)
-    #define TracyMetalZone(ctx, encoderDesc, name)
-    #define TracyMetalCollect(ctx)
-    namespace tracy { class MetalCtx; }
+#if defined (GFX_BUILD_METAL)
+    #if defined(GFX_BUILD_TRACY) && defined(__OBJC__) && (defined(__aarch64__) || defined(__arm64__))
+        #include <tracy/TracyMetal.hmm>
+    #else
+        #define TracyMetalContext(device) nullptr
+        #define TracyMetalDestroy(ctx)
+        #define TracyMetalZone(ctx, encoderDesc, name)
+        #define TracyMetalCollect(ctx)
+        using TracyMetalCtx = void*;
+    #endif
 #endif
-#if defined(GFX_BUILD_TRACY) && defined(GFX_BUILD_VULKAN)
-    #define TRACY_VK_USE_SYMBOL_TABLE
-    #include <tracy/TracyVulkan.hpp>
-    #define TracyVkZone_begin(ctx, cmdbuf, name, variable, active)                                                                   \
-        static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location, TracyLine){                              \
-            name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0                                                                   \
-        };                                                                                                                           \
-        (variable) = std::make_shared<tracy::VkCtxScope>(ctx, &TracyConcat(__tracy_gpu_source_location, TracyLine), cmdbuf, active);
-    #define TracyVkZone_end(variable) variable.reset()
-#else
-    #define TracyVkContextHostCalibrated(instance, physdev, device, instanceProcAddr, deviceProcAddr) nullptr
-    #define TracyVkZone(ctx, cmdbuf, name)
-    #define TracyVkCollectHost(ctx)
-    #define TracyVkDestroy(ctx)
-    namespace tracy { class VkCtx; }
-    #define TracyVkZone_begin(ctx, cmdbuf, name, variable, active)
-    #define TracyVkZone_end(variable)
+
+#if defined (GFX_BUILD_VULKAN)
+    #if defined(GFX_BUILD_TRACY)
+        #define TRACY_VK_USE_SYMBOL_TABLE
+        #include <tracy/TracyVulkan.hpp>
+        #if defined (TRACY_ENABLE)
+            #define TracyVkZone_begin(ctx, cmdbuf, name, variable, active)                                                                   \
+                static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location, TracyLine){                              \
+                    name, TracyFunction, TracyFile, (uint32_t)TracyLine, 0                                                                   \
+                };                                                                                                                           \
+                (variable) = std::make_shared<tracy::VkCtxScope>(ctx, &TracyConcat(__tracy_gpu_source_location, TracyLine), cmdbuf, active);
+            #define TracyVkZone_end(variable) variable.reset()
+        #else
+            #define TracyVkZone_begin(ctx, cmdbuf, name, variable, active)
+            #define TracyVkZone_end(variable)
+        #endif
+    #else
+        #define TracyVkContextHostCalibrated(instance, physdev, device, instanceProcAddr, deviceProcAddr) nullptr
+        #define TracyVkZone(ctx, cmdbuf, name)
+        #define TracyVkCollectHost(ctx)
+        #define TracyVkDestroy(ctx)
+        using TracyVkCtx = void*;
+        #define TracyVkZone_begin(ctx, cmdbuf, name, variable, active)
+        #define TracyVkZone_end(variable)
+    #endif
 #endif
 // NOLINTEND(cppcoreguidelines-macro-usage)
 


### PR DESCRIPTION
Enable TracyClient only for non-Release builds and keep Metal/Vulkan
stub context types and macros available when profiling is disabled.
