### PR TITLE
uint32/64 render target support

### DIFF
--- a/examples/descriptor_indexing/descriptor_indexing.cpp
+++ b/examples/descriptor_indexing/descriptor_indexing.cpp
@@ -325,7 +325,7 @@ public:
                 .colorAttachments = {
                     gfx::Framebuffer::Attachment{
                         .loadAction = gfx::LoadAction::clear,
-                        .clearColor = { 0.08f, 0.08f, 0.10f, 1.0f },
+                        .clearValue = gfx::ClearValue::color({0.08f, 0.08f, 0.10f, 1.0f}),
                         .texture = drawable->texture()
                     }
                 }

--- a/examples/imgui_usage/imgui_usage.cpp
+++ b/examples/imgui_usage/imgui_usage.cpp
@@ -213,7 +213,7 @@ public:
                 .colorAttachments = {
                     gfx::Framebuffer::Attachment{
                         .loadAction = gfx::LoadAction::clear,
-                        .clearColor = { 0.0f, 0.0f, 0.0f, 0.0f },
+                        .clearValue = gfx::ClearValue::color({0.0f, 0.0f, 0.0f, 0.0f}),
                         .texture = drawable->texture()
                     }
                 }

--- a/examples/mc_cube/mc_cube.cpp
+++ b/examples/mc_cube/mc_cube.cpp
@@ -448,14 +448,14 @@ public:
                 .colorAttachments = {
                     gfx::Framebuffer::Attachment{
                         .loadAction = gfx::LoadAction::clear,
-                        .clearColor = { 0.0f, 0.0f, 0.0f, 0.0f },
+                        .clearValue = gfx::ClearValue::color({0.0f, 0.0f, 0.0f, 0.0f}),
                         .texture = drawable->texture()
                     }
                 },
                 .depthAttachment = {
                     gfx::Framebuffer::Attachment{
                         .loadAction = gfx::LoadAction::clear,
-                        .clearDepth = 1.0f,
+                        .clearValue = gfx::ClearValue::depth(1.0f),
                         .texture = m_depthTexture.at(m_frameIdx)
                     }
                 }

--- a/examples/multiBuffer/multiBuffer.cpp
+++ b/examples/multiBuffer/multiBuffer.cpp
@@ -222,7 +222,7 @@ public:
                 .colorAttachments = {
                     gfx::Framebuffer::Attachment{
                         .loadAction = gfx::LoadAction::clear,
-                        .clearColor = {0.0f, 0.0f, 0.0f, 0.0f },
+                        .clearValue = gfx::ClearValue::color({0.0f, 0.0f, 0.0f, 0.0f}),
                         .texture = drawable->texture()
                     }
                 }

--- a/examples/scop/Renderer.cpp
+++ b/examples/scop/Renderer.cpp
@@ -227,14 +227,14 @@ void Renderer::endFrame()
         .colorAttachments = {
             gfx::Framebuffer::Attachment{
                 .loadAction = gfx::LoadAction::clear,
-                .clearColor = {0.0f, 0.0f, 0.0f, 0.0f},
+                .clearValue = gfx::ClearValue::color({0.0f, 0.0f, 0.0f, 0.0f}),
                 .texture = drawable->texture()
             }
         },
         .depthAttachment = {
             gfx::Framebuffer::Attachment{
                 .loadAction = gfx::LoadAction::clear,
-                .clearDepth = 1.0f,
+                .clearValue = gfx::ClearValue::depth(1.0f),
                 .texture = cfd.depthTexture
             }
         }

--- a/examples/triangle/triangle.cpp
+++ b/examples/triangle/triangle.cpp
@@ -183,7 +183,7 @@ public:
                 .colorAttachments = {
                     gfx::Framebuffer::Attachment{
                         .loadAction = gfx::LoadAction::clear,
-                        .clearColor = { 0.0f, 0.0f, 0.0f, 0.0f },
+                        .clearValue = gfx::ClearValue::color({0.0f, 0.0f, 0.0f, 0.0f}),
                         .texture = drawable->texture()
                     }
                 }

--- a/include/Graphics/CommandBuffer.hpp
+++ b/include/Graphics/CommandBuffer.hpp
@@ -57,6 +57,9 @@ public:
     virtual void copyBufferToBuffer(const std::shared_ptr<Buffer>& src, const std::shared_ptr<Buffer>& dst, size_t size) = 0;
     virtual void copyBufferToTexture(const std::shared_ptr<Buffer>& buffer, size_t bufferOffset, const std::shared_ptr<Texture>& texture, uint32_t layerIndex = 0) = 0;
     inline void copyBufferToTexture(const std::shared_ptr<Buffer>& buffer, const std::shared_ptr<Texture>& texture) { copyBufferToTexture(buffer, 0, texture); }
+    virtual void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, uint32_t layerIndex, const std::shared_ptr<Buffer>& buffer, size_t bufferOffset) = 0;
+    inline void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, const std::shared_ptr<Buffer>& buffer) { copyTextureToBuffer(texture, 0, buffer, 0); }
+    inline void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, const std::shared_ptr<Buffer>& buffer, size_t bufferOffset) { copyTextureToBuffer(texture, 0, buffer, bufferOffset); }
 
     virtual void endBlitPass() = 0;
 

--- a/include/Graphics/CommandBuffer.hpp
+++ b/include/Graphics/CommandBuffer.hpp
@@ -55,8 +55,10 @@ public:
     virtual void beginBlitPass() = 0;
 
     virtual void copyBufferToBuffer(const std::shared_ptr<Buffer>& src, const std::shared_ptr<Buffer>& dst, size_t size) = 0;
+
     virtual void copyBufferToTexture(const std::shared_ptr<Buffer>& buffer, size_t bufferOffset, const std::shared_ptr<Texture>& texture, uint32_t layerIndex = 0) = 0;
     inline void copyBufferToTexture(const std::shared_ptr<Buffer>& buffer, const std::shared_ptr<Texture>& texture) { copyBufferToTexture(buffer, 0, texture); }
+
     virtual void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, uint32_t layerIndex, const std::shared_ptr<Buffer>& buffer, size_t bufferOffset) = 0;
     inline void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, const std::shared_ptr<Buffer>& buffer) { copyTextureToBuffer(texture, 0, buffer, 0); }
     inline void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, const std::shared_ptr<Buffer>& buffer, size_t bufferOffset) { copyTextureToBuffer(texture, 0, buffer, bufferOffset); }

--- a/include/Graphics/Enums.hpp
+++ b/include/Graphics/Enums.hpp
@@ -175,7 +175,8 @@ enum class TextureUsage : uint8_t
     shaderRead             = 1 << 0,
     colorAttachment        = 1 << 1,
     depthStencilAttachment = 1 << 2,
-    copyDestination        = 1 << 3
+    copyDestination        = 1 << 3,
+    copySource             = 1 << 4
 };
 GFX_ENABLE_BITMASK_OPERATORS(TextureUsage);
 using TextureUsages = Flags<TextureUsage>;

--- a/include/Graphics/Enums.hpp
+++ b/include/Graphics/Enums.hpp
@@ -95,6 +95,7 @@ enum class PixelFormat : uint8_t
     RGBA8Unorm,
     BGRA8Unorm,
     BGRA8Unorm_sRGB,
+    RG32Uint,
     Depth32Float
 };
 
@@ -216,6 +217,8 @@ constexpr inline size_t pixelFormatSize(PixelFormat format)
     case PixelFormat::BGRA8Unorm_sRGB:
     case PixelFormat::Depth32Float:
         return 4;
+    case PixelFormat::RG32Uint:
+        return 8;
     default:
         throw std::runtime_error("not implemented");
     }

--- a/include/Graphics/Framebuffer.hpp
+++ b/include/Graphics/Framebuffer.hpp
@@ -17,17 +17,53 @@
 #include <memory>
 #include <optional>
 #include <array>
+#include <cstdint>
+#include <variant>
 
 namespace gfx
 {
 
+struct ClearFloatColor
+{
+    std::array<float, 4> value;
+};
+
+struct ClearUIntColor
+{
+    std::array<uint32_t, 4> value;
+};
+
+struct ClearDepth
+{
+    float value;
+};
+
+struct ClearValue
+{
+    using Value = std::variant<ClearFloatColor, ClearUIntColor, ClearDepth>;
+
+    Value value = ClearFloatColor{{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    static ClearValue color(std::array<float, 4> value) { return ClearValue{ClearFloatColor{value}}; }
+    static ClearValue uintColor(std::array<uint32_t, 4> value) { return ClearValue{ClearUIntColor{value}}; }
+    static ClearValue uint64(uint64_t value)
+    {
+        return uintColor({
+            static_cast<uint32_t>(value),
+            static_cast<uint32_t>(value >> 32),
+            0,
+            0
+        });
+    }
+    static ClearValue depth(float value) { return ClearValue{ClearDepth{value}}; }
+};
 
 struct Framebuffer
 {
     struct Attachment
     {
         LoadAction loadAction = LoadAction::load;
-        union { std::array<float, 4> clearColor; float clearDepth; };
+        ClearValue clearValue = ClearValue::color({0.0f, 0.0f, 0.0f, 0.0f});
         std::shared_ptr<Texture> texture;
     };
 

--- a/src/Metal/MetalCommandBuffer.hpp
+++ b/src/Metal/MetalCommandBuffer.hpp
@@ -62,6 +62,7 @@ public:
 
     void copyBufferToBuffer(const std::shared_ptr<Buffer>& src, const std::shared_ptr<Buffer>& dst, size_t size) override;
     void copyBufferToTexture(const std::shared_ptr<Buffer>& buffer, size_t bufferOffset, const std::shared_ptr<Texture>& texture, uint32_t layerIndex = 0) override;
+    void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, uint32_t layerIndex, const std::shared_ptr<Buffer>& buffer, size_t bufferOffset) override;
 
     void endBlitPass() override;
 

--- a/src/Metal/MetalCommandBuffer.mm
+++ b/src/Metal/MetalCommandBuffer.mm
@@ -20,6 +20,7 @@
 #include "Metal/MetalSampler.hpp"
 #include "Metal/MetalTexture.hpp"
 #include <memory>
+#include <utility>
 #if defined(GFX_IMGUI_ENABLED)
 # include "Metal/imgui_impl_metal.h"
 #endif
@@ -37,38 +38,13 @@ namespace gfx
 
 namespace
 {
-    constexpr bool isFloatColorFormat(PixelFormat format)
+    MTLClearColor toMTLClearColor(const ClearValue& clearValue)
     {
-        switch (format)
-        {
-        case PixelFormat::RGBA8Unorm:
-        case PixelFormat::BGRA8Unorm:
-        case PixelFormat::BGRA8Unorm_sRGB:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    MTLClearColor toMTLClearColor(const ClearValue& clearValue, PixelFormat pixelFormat)
-    {
-        return std::visit([pixelFormat](const auto& clear) -> MTLClearColor {
-            using Clear = std::decay_t<decltype(clear)>;
-            if constexpr (std::is_same_v<Clear, ClearFloatColor>)
-            {
-                assert(isFloatColorFormat(pixelFormat));
+        return std::visit([]<typename T>(const T& clear) -> MTLClearColor {
+            if constexpr (std::is_same_v<T, ClearFloatColor> || std::is_same_v<T, ClearUIntColor>)
                 return MTLClearColorMake(clear.value[0], clear.value[1], clear.value[2], clear.value[3]);
-            }
-            else if constexpr (std::is_same_v<Clear, ClearUIntColor>)
-            {
-                assert(pixelFormat == PixelFormat::RG32Uint);
-                return MTLClearColorMake(clear.value[0], clear.value[1], clear.value[2], clear.value[3]);
-            }
             else
-            {
-                assert(false);
-                return MTLClearColorMake(0, 0, 0, 0);
-            }
+                std::unreachable();
         }, clearValue.value);
     }
 
@@ -109,7 +85,7 @@ void MetalCommandBuffer::beginRenderPass(const Framebuffer& framebuffer) { @auto
         assert(texture);
         renderPassDescriptor.colorAttachments[i].loadAction = toMTLLoadAction(colorAttachment.loadAction);
         renderPassDescriptor.colorAttachments[i].storeAction = MTLStoreActionStore;
-        renderPassDescriptor.colorAttachments[i].clearColor = toMTLClearColor(colorAttachment.clearValue, texture->pixelFormat());
+        renderPassDescriptor.colorAttachments[i].clearColor = toMTLClearColor(colorAttachment.clearValue);
         renderPassDescriptor.colorAttachments[i].texture = texture->mtltexture();
         m_usedTextures.insert(texture);
 

--- a/src/Metal/MetalCommandBuffer.mm
+++ b/src/Metal/MetalCommandBuffer.mm
@@ -30,8 +30,55 @@
 
 #import "Metal/MetalEnums.hpp"
 
+#include <type_traits>
+
 namespace gfx
 {
+
+namespace
+{
+    constexpr bool isFloatColorFormat(PixelFormat format)
+    {
+        switch (format)
+        {
+        case PixelFormat::RGBA8Unorm:
+        case PixelFormat::BGRA8Unorm:
+        case PixelFormat::BGRA8Unorm_sRGB:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    MTLClearColor toMTLClearColor(const ClearValue& clearValue, PixelFormat pixelFormat)
+    {
+        return std::visit([pixelFormat](const auto& clear) -> MTLClearColor {
+            using Clear = std::decay_t<decltype(clear)>;
+            if constexpr (std::is_same_v<Clear, ClearFloatColor>)
+            {
+                assert(isFloatColorFormat(pixelFormat));
+                return MTLClearColorMake(clear.value[0], clear.value[1], clear.value[2], clear.value[3]);
+            }
+            else if constexpr (std::is_same_v<Clear, ClearUIntColor>)
+            {
+                assert(pixelFormat == PixelFormat::RG32Uint);
+                return MTLClearColorMake(clear.value[0], clear.value[1], clear.value[2], clear.value[3]);
+            }
+            else
+            {
+                assert(false);
+                return MTLClearColorMake(0, 0, 0, 0);
+            }
+        }, clearValue.value);
+    }
+
+    double toMTLClearDepth(const ClearValue& clearValue)
+    {
+        const auto* clearDepth = std::get_if<ClearDepth>(&clearValue.value);
+        assert(clearDepth);
+        return clearDepth->value;
+    }
+}
 
 MetalCommandBuffer::MetalCommandBuffer(MetalCommandBuffer&& other) noexcept
     : CommandBuffer(std::move(other)),
@@ -62,9 +109,7 @@ void MetalCommandBuffer::beginRenderPass(const Framebuffer& framebuffer) { @auto
         assert(texture);
         renderPassDescriptor.colorAttachments[i].loadAction = toMTLLoadAction(colorAttachment.loadAction);
         renderPassDescriptor.colorAttachments[i].storeAction = MTLStoreActionStore;
-        renderPassDescriptor.colorAttachments[i].clearColor = MTLClearColorMake(
-            colorAttachment.clearColor[0], colorAttachment.clearColor[1],
-            colorAttachment.clearColor[2], colorAttachment.clearColor[3]);
+        renderPassDescriptor.colorAttachments[i].clearColor = toMTLClearColor(colorAttachment.clearValue, texture->pixelFormat());
         renderPassDescriptor.colorAttachments[i].texture = texture->mtltexture();
         m_usedTextures.insert(texture);
 
@@ -76,7 +121,7 @@ void MetalCommandBuffer::beginRenderPass(const Framebuffer& framebuffer) { @auto
         auto texture = std::dynamic_pointer_cast<MetalTexture>(depthAttachment->texture);
         renderPassDescriptor.depthAttachment.loadAction = toMTLLoadAction(depthAttachment->loadAction);
         renderPassDescriptor.depthAttachment.storeAction = MTLStoreActionStore;
-        renderPassDescriptor.depthAttachment.clearDepth = depthAttachment->clearDepth;
+        renderPassDescriptor.depthAttachment.clearDepth = toMTLClearDepth(depthAttachment->clearValue);
         renderPassDescriptor.depthAttachment.texture = texture->mtltexture();
         m_usedTextures.insert(texture);
     }

--- a/src/Metal/MetalCommandBuffer.mm
+++ b/src/Metal/MetalCommandBuffer.mm
@@ -67,6 +67,8 @@ void MetalCommandBuffer::beginRenderPass(const Framebuffer& framebuffer) { @auto
             colorAttachment.clearColor[2], colorAttachment.clearColor[3]);
         renderPassDescriptor.colorAttachments[i].texture = texture->mtltexture();
         m_usedTextures.insert(texture);
+
+        i++;
     }
 
     if (auto& depthAttachment = framebuffer.depthAttachment)

--- a/src/Metal/MetalCommandBuffer.mm
+++ b/src/Metal/MetalCommandBuffer.mm
@@ -213,6 +213,8 @@ void MetalCommandBuffer::copyBufferToBuffer(const std::shared_ptr<Buffer>& aSrc,
     assert(dst);
 
     assert(src->usages() & BufferUsage::copySource && dst->usages() & BufferUsage::copyDestination);
+    assert(size <= src->size());
+    assert(size <= dst->size());
 
     assert([m_commandEncoder conformsToProtocol:@protocol(MTLBlitCommandEncoder)]);
     auto blitCommandEncoder = (id<MTLBlitCommandEncoder>)m_commandEncoder;
@@ -231,6 +233,8 @@ void MetalCommandBuffer::copyBufferToTexture(const std::shared_ptr<Buffer>& aBuf
     auto texture = std::dynamic_pointer_cast<MetalTexture>(aTexture);
     assert(texture);
 
+    assert(buffer->usages() & BufferUsage::copySource);
+    assert(texture->usages() & TextureUsage::copyDestination);
     assert([m_commandEncoder conformsToProtocol:@protocol(MTLBlitCommandEncoder)]);
 
     size_t bytesPerPixel = pixelFormatSize(texture->pixelFormat());
@@ -251,6 +255,38 @@ void MetalCommandBuffer::copyBufferToTexture(const std::shared_ptr<Buffer>& aBuf
 
     m_usedBuffers.insert(buffer);
     m_usedTextures.insert(texture);
+}}
+
+void MetalCommandBuffer::copyTextureToBuffer(const std::shared_ptr<Texture>& aTexture, uint32_t layerIndex, const std::shared_ptr<Buffer>& aBuffer, size_t bufferOffset) { @autoreleasepool
+{
+    auto texture = std::dynamic_pointer_cast<MetalTexture>(aTexture);
+    assert(texture);
+
+    auto buffer = std::dynamic_pointer_cast<MetalBuffer>(aBuffer);
+    assert(buffer);
+
+    assert(texture->usages() & TextureUsage::copySource);
+    assert(buffer->usages() & BufferUsage::copyDestination);
+    assert([m_commandEncoder conformsToProtocol:@protocol(MTLBlitCommandEncoder)]);
+
+    size_t bytesPerPixel = pixelFormatSize(texture->pixelFormat());
+    size_t bytesPerRow = bytesPerPixel * texture->width();
+    size_t bytesPerImage = bytesPerRow * texture->height();
+
+    assert(bufferOffset + bytesPerImage <= buffer->size());
+
+    [(id<MTLBlitCommandEncoder>)m_commandEncoder copyFromTexture:texture->mtltexture()
+                                                     sourceSlice:layerIndex
+                                                     sourceLevel:0
+                                                    sourceOrigin:MTLOrigin{0, 0, 0}
+                                                      sourceSize:MTLSizeMake(texture->width(), texture->height(), 1)
+                                                        toBuffer:buffer->mtlBuffer()
+                                               destinationOffset:bufferOffset
+                                          destinationBytesPerRow:bytesPerRow
+                                        destinationBytesPerImage:bytesPerImage];
+
+    m_usedTextures.insert(texture);
+    m_usedBuffers.insert(buffer);
 }}
 
 void MetalCommandBuffer::endBlitPass() { @autoreleasepool

--- a/src/Metal/MetalEnums.hpp
+++ b/src/Metal/MetalEnums.hpp
@@ -29,6 +29,8 @@ constexpr MTLPixelFormat toMTLPixelFormat(PixelFormat pxf)
         return MTLPixelFormatBGRA8Unorm;
     case PixelFormat::BGRA8Unorm_sRGB:
         return MTLPixelFormatBGRA8Unorm_sRGB;
+    case PixelFormat::RG32Uint:
+        return MTLPixelFormatRG32Uint;
     case PixelFormat::Depth32Float:
         return MTLPixelFormatDepth32Float;
     default:
@@ -46,6 +48,8 @@ constexpr PixelFormat toPixelFormat(MTLPixelFormat pxf)
         return PixelFormat::BGRA8Unorm;
     case MTLPixelFormatBGRA8Unorm_sRGB:
         return PixelFormat::BGRA8Unorm_sRGB;
+    case MTLPixelFormatRG32Uint:
+        return PixelFormat::RG32Uint;
     default:
         throw std::runtime_error("not implemented");
     }

--- a/src/Metal/MetalGraphicsPipeline.mm
+++ b/src/Metal/MetalGraphicsPipeline.mm
@@ -88,6 +88,8 @@ MetalGraphicsPipeline::MetalGraphicsPipeline(const MetalDevice& device, const Gr
                 std::unreachable();
             }
         }
+
+        i++;
     }
 
     if (auto& depthPxFmt = desc.depthAttachmentPxFormat)

--- a/src/Vulkan/VulkanCommandBuffer.cpp
+++ b/src/Vulkan/VulkanCommandBuffer.cpp
@@ -107,6 +107,8 @@ void VulkanCommandBuffer::beginRenderPass(const Framebuffer& framebuffer)
             m_imageSyncRequests[texture] = syncReq;
             m_imageFinalSyncStates[texture] = imageStateAfterSync(syncReq);
         }
+
+        i++;
     }
 
     if (auto& depthAttachment = framebuffer.depthAttachment)

--- a/src/Vulkan/VulkanCommandBuffer.cpp
+++ b/src/Vulkan/VulkanCommandBuffer.cpp
@@ -29,6 +29,8 @@
 #include "Vulkan/VulkanCommandBufferPool.hpp"
 #include "Vulkan/VulkanDevice.hpp"
 
+#include <type_traits>
+
 #define m_usedPipelines m_nonReusedRessources.usedPipelines
 #define m_boundPipeline m_nonReusedRessources.boundPipeline
 #define m_usedPBlock m_nonReusedRessources.usedPBlock
@@ -40,6 +42,51 @@
 
 namespace gfx
 {
+
+namespace
+{
+    constexpr bool isFloatColorFormat(PixelFormat format)
+    {
+        switch (format)
+        {
+        case PixelFormat::RGBA8Unorm:
+        case PixelFormat::BGRA8Unorm:
+        case PixelFormat::BGRA8Unorm_sRGB:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    vk::ClearValue toVkColorClearValue(const ClearValue& clearValue, PixelFormat pixelFormat)
+    {
+        return std::visit([pixelFormat](const auto& clear) -> vk::ClearValue {
+            using Clear = std::decay_t<decltype(clear)>;
+            if constexpr (std::is_same_v<Clear, ClearFloatColor>)
+            {
+                assert(isFloatColorFormat(pixelFormat));
+                return vk::ClearValue{}.setColor(vk::ClearColorValue{}.setFloat32(clear.value));
+            }
+            else if constexpr (std::is_same_v<Clear, ClearUIntColor>)
+            {
+                assert(pixelFormat == PixelFormat::RG32Uint);
+                return vk::ClearValue{}.setColor(vk::ClearColorValue{}.setUint32(clear.value));
+            }
+            else
+            {
+                assert(false);
+                return {};
+            }
+        }, clearValue.value);
+    }
+
+    vk::ClearValue toVkDepthClearValue(const ClearValue& clearValue)
+    {
+        const auto* clearDepth = std::get_if<ClearDepth>(&clearValue.value);
+        assert(clearDepth);
+        return vk::ClearValue{}.setDepthStencil(vk::ClearDepthStencilValue{}.setDepth(clearDepth->value));
+    }
+}
 
 VulkanCommandBuffer::VulkanCommandBuffer(const VulkanDevice* device, const std::shared_ptr<vk::CommandPool>& commandPool)
     : m_device(device),
@@ -81,11 +128,7 @@ void VulkanCommandBuffer::beginRenderPass(const Framebuffer& framebuffer)
 
         colorAttachmentInfos[i] = vk::RenderingAttachmentInfo{}
             .setLoadOp(toVkAttachmentLoadOp(colorAttachment.loadAction))
-            .setClearValue(vk::ClearValue{}.setColor(vk::ClearColorValue{}.setFloat32({
-                  colorAttachment.clearColor[0],
-                  colorAttachment.clearColor[1],
-                  colorAttachment.clearColor[2],
-                  colorAttachment.clearColor[3]})))
+            .setClearValue(toVkColorClearValue(colorAttachment.clearValue, texture->pixelFormat()))
             .setImageView(texture->vkImageView())
             .setImageLayout(vk::ImageLayout::eColorAttachmentOptimal);
 
@@ -118,7 +161,7 @@ void VulkanCommandBuffer::beginRenderPass(const Framebuffer& framebuffer)
 
         depthAttachmentInfo = vk::RenderingAttachmentInfo{}
             .setLoadOp(toVkAttachmentLoadOp(depthAttachment->loadAction))
-            .setClearValue(vk::ClearValue{}.setDepthStencil(vk::ClearDepthStencilValue{}.setDepth(depthAttachment->clearDepth)))
+            .setClearValue(toVkDepthClearValue(depthAttachment->clearValue))
             .setImageView(texture->vkImageView())
             .setImageLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal);
 

--- a/src/Vulkan/VulkanCommandBuffer.cpp
+++ b/src/Vulkan/VulkanCommandBuffer.cpp
@@ -45,38 +45,15 @@ namespace gfx
 
 namespace
 {
-    constexpr bool isFloatColorFormat(PixelFormat format)
+    vk::ClearValue toVkColorClearValue(const ClearValue& clearValue)
     {
-        switch (format)
-        {
-        case PixelFormat::RGBA8Unorm:
-        case PixelFormat::BGRA8Unorm:
-        case PixelFormat::BGRA8Unorm_sRGB:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    vk::ClearValue toVkColorClearValue(const ClearValue& clearValue, PixelFormat pixelFormat)
-    {
-        return std::visit([pixelFormat](const auto& clear) -> vk::ClearValue {
-            using Clear = std::decay_t<decltype(clear)>;
-            if constexpr (std::is_same_v<Clear, ClearFloatColor>)
-            {
-                assert(isFloatColorFormat(pixelFormat));
+        return std::visit([]<typename T>(const T& clear) -> vk::ClearValue {
+            if constexpr (std::is_same_v<T, ClearFloatColor>)
                 return vk::ClearValue{}.setColor(vk::ClearColorValue{}.setFloat32(clear.value));
-            }
-            else if constexpr (std::is_same_v<Clear, ClearUIntColor>)
-            {
-                assert(pixelFormat == PixelFormat::RG32Uint);
+            else if constexpr (std::is_same_v<T, ClearUIntColor>)
                 return vk::ClearValue{}.setColor(vk::ClearColorValue{}.setUint32(clear.value));
-            }
             else
-            {
-                assert(false);
-                return {};
-            }
+                std::unreachable();
         }, clearValue.value);
     }
 
@@ -128,7 +105,7 @@ void VulkanCommandBuffer::beginRenderPass(const Framebuffer& framebuffer)
 
         colorAttachmentInfos[i] = vk::RenderingAttachmentInfo{}
             .setLoadOp(toVkAttachmentLoadOp(colorAttachment.loadAction))
-            .setClearValue(toVkColorClearValue(colorAttachment.clearValue, texture->pixelFormat()))
+            .setClearValue(toVkColorClearValue(colorAttachment.clearValue))
             .setImageView(texture->vkImageView())
             .setImageLayout(vk::ImageLayout::eColorAttachmentOptimal);
 

--- a/src/Vulkan/VulkanCommandBuffer.cpp
+++ b/src/Vulkan/VulkanCommandBuffer.cpp
@@ -382,6 +382,8 @@ void VulkanCommandBuffer::copyBufferToBuffer(const std::shared_ptr<Buffer>& aSrc
 
     assert(src->usages() & BufferUsage::copySource);
     assert(dst->usages() & BufferUsage::copyDestination);
+    assert(size <= src->size());
+    assert(size <= dst->size());
 
     std::vector<vk::BufferMemoryBarrier2> bufferMemoryBarriers;
 
@@ -516,6 +518,88 @@ void VulkanCommandBuffer::copyBufferToTexture(const std::shared_ptr<Buffer>& aBu
         buffer->vkBuffer(),
         texture->vkImage(),
         vk::ImageLayout::eTransferDstOptimal,
+        bufferImageCopy);
+}
+
+void VulkanCommandBuffer::copyTextureToBuffer(const std::shared_ptr<Texture>& aTexture, uint32_t layerIndex, const std::shared_ptr<Buffer>& aBuffer, size_t bufferOffset)
+{
+    auto texture = std::dynamic_pointer_cast<VulkanTexture>(aTexture);
+    assert(texture);
+    auto buffer = std::dynamic_pointer_cast<VulkanBuffer>(aBuffer);
+    assert(buffer);
+
+    assert(texture->usages() & TextureUsage::copySource);
+    assert(buffer->usages() & BufferUsage::copyDestination);
+    assert(bufferOffset + pixelFormatSize(texture->pixelFormat()) * texture->width() * texture->height() <= buffer->size());
+
+    std::vector<vk::ImageMemoryBarrier2> imageMemoryBarriers;
+    std::vector<vk::BufferMemoryBarrier2> bufferMemoryBarriers;
+
+    ImageSyncRequest imageSyncReq{};
+    imageSyncReq.stageMask = vk::PipelineStageFlagBits2::eTransfer;
+    imageSyncReq.accessMask = vk::AccessFlagBits2::eTransferRead;
+    imageSyncReq.layout = vk::ImageLayout::eTransferSrcOptimal;
+
+    auto imageIt = m_imageFinalSyncStates.find(texture);
+    if (imageIt != m_imageFinalSyncStates.end()) {
+        auto barrier = syncImage(imageIt->second, imageSyncReq); // will update the final sync state
+        if (barrier.has_value()) {
+            barrier->setImage(texture->vkImage());
+            barrier->setSubresourceRange(texture->subresourceRange());
+            imageMemoryBarriers.push_back(*barrier);
+        }
+    } else {
+        m_imageSyncRequests[texture] = imageSyncReq;
+        m_imageFinalSyncStates[texture] = imageStateAfterSync(imageSyncReq);
+    }
+
+    BufferSyncRequest bufferSyncReq{};
+    bufferSyncReq.stageMask = vk::PipelineStageFlagBits2::eTransfer;
+    bufferSyncReq.accessMask = vk::AccessFlagBits2::eTransferWrite;
+
+    auto bufferIt = m_bufferFinalSyncStates.find(buffer);
+    if (bufferIt != m_bufferFinalSyncStates.end()) {
+        auto barrier = syncBuffer(bufferIt->second, bufferSyncReq); // will update the final sync state
+        if (barrier.has_value()) {
+            barrier->setBuffer(buffer->vkBuffer());
+            barrier->setOffset(0);
+            barrier->setSize(vk::WholeSize);
+            bufferMemoryBarriers.push_back(*barrier);
+        }
+    } else {
+        m_bufferSyncRequests[buffer] = bufferSyncReq;
+        m_bufferFinalSyncStates[buffer] = bufferStateAfterSync(bufferSyncReq);
+    }
+
+    if (imageMemoryBarriers.empty() == false || bufferMemoryBarriers.empty() == false)
+    {
+        auto dependencyInfo = vk::DependencyInfo{}
+            .setDependencyFlags(vk::DependencyFlags{});
+
+        if (imageMemoryBarriers.empty() == false)
+            dependencyInfo.setImageMemoryBarriers(imageMemoryBarriers);
+        if (bufferMemoryBarriers.empty() == false)
+            dependencyInfo.setBufferMemoryBarriers(bufferMemoryBarriers);
+
+        m_vkCommandBuffer.pipelineBarrier2(dependencyInfo);
+    }
+
+    auto bufferImageCopy = vk::BufferImageCopy{}
+        .setBufferOffset(bufferOffset)
+        .setImageSubresource(vk::ImageSubresourceLayers{}
+            .setAspectMask(texture->subresourceRange().aspectMask)
+            .setMipLevel(0)
+            .setBaseArrayLayer(layerIndex)
+            .setLayerCount(1))
+        .setImageExtent(vk::Extent3D{}
+            .setWidth(texture->width())
+            .setHeight(texture->height())
+            .setDepth(1));
+
+    m_vkCommandBuffer.copyImageToBuffer(
+        texture->vkImage(),
+        vk::ImageLayout::eTransferSrcOptimal,
+        buffer->vkBuffer(),
         bufferImageCopy);
 }
 

--- a/src/Vulkan/VulkanCommandBuffer.hpp
+++ b/src/Vulkan/VulkanCommandBuffer.hpp
@@ -61,6 +61,7 @@ public:
 
     void copyBufferToBuffer(const std::shared_ptr<Buffer>& src, const std::shared_ptr<Buffer>& dst, size_t size) override;
     void copyBufferToTexture(const std::shared_ptr<Buffer>& buffer, size_t bufferOffset, const std::shared_ptr<Texture>& texture, uint32_t layerIndex = 0) override;
+    void copyTextureToBuffer(const std::shared_ptr<Texture>& texture, uint32_t layerIndex, const std::shared_ptr<Buffer>& buffer, size_t bufferOffset) override;
 
     void endBlitPass() override;
 

--- a/src/Vulkan/VulkanEnums.hpp
+++ b/src/Vulkan/VulkanEnums.hpp
@@ -25,6 +25,8 @@ constexpr vk::Format toVkFormat(PixelFormat pxf)
         return vk::Format::eB8G8R8A8Unorm;
     case PixelFormat::BGRA8Unorm_sRGB:
         return vk::Format::eB8G8R8A8Srgb;
+    case PixelFormat::RG32Uint:
+        return vk::Format::eR32G32Uint;
     case PixelFormat::Depth32Float:
         return vk::Format::eD32Sfloat;
     default:
@@ -40,6 +42,8 @@ constexpr PixelFormat toPixelFormat(vk::Format fmt)
         return PixelFormat::BGRA8Unorm;
     case vk::Format::eB8G8R8A8Srgb:
         return PixelFormat::BGRA8Unorm_sRGB;
+    case vk::Format::eR32G32Uint:
+        return PixelFormat::RG32Uint;
     default:
         throw std::runtime_error("not implemented");
     }
@@ -187,6 +191,7 @@ constexpr vk::ImageAspectFlags toVkImageAspectFlags(PixelFormat format)
     case PixelFormat::RGBA8Unorm:
     case PixelFormat::BGRA8Unorm:
     case PixelFormat::BGRA8Unorm_sRGB:
+    case PixelFormat::RG32Uint:
         return vk::ImageAspectFlagBits::eColor;
     case PixelFormat::Depth32Float:
         return vk::ImageAspectFlagBits::eDepth;

--- a/src/Vulkan/VulkanEnums.hpp
+++ b/src/Vulkan/VulkanEnums.hpp
@@ -174,22 +174,25 @@ constexpr vk::ImageUsageFlags toVkImageUsageFlags(TextureUsages use)
         vkUsages |= vk::ImageUsageFlagBits::eDepthStencilAttachment;
     if (use & TextureUsage::copyDestination)
         vkUsages |= vk::ImageUsageFlagBits::eTransferDst;
+    if (use & TextureUsage::copySource)
+        vkUsages |= vk::ImageUsageFlagBits::eTransferSrc;
 
     return vkUsages;
 }
 
-constexpr vk::ImageAspectFlags toVkImageAspectFlags(TextureUsages use)
+constexpr vk::ImageAspectFlags toVkImageAspectFlags(PixelFormat format)
 {
-    vk::ImageAspectFlags vkImgAspectFlags;
-
-    if (use & TextureUsage::shaderRead)
-        vkImgAspectFlags |= vk::ImageAspectFlagBits::eColor;
-    if (use & TextureUsage::colorAttachment)
-        vkImgAspectFlags |= vk::ImageAspectFlagBits::eColor;
-    if (use & TextureUsage::depthStencilAttachment)
-        vkImgAspectFlags |= vk::ImageAspectFlagBits::eDepth;
-
-    return vkImgAspectFlags;
+    switch (format)
+    {
+    case PixelFormat::RGBA8Unorm:
+    case PixelFormat::BGRA8Unorm:
+    case PixelFormat::BGRA8Unorm_sRGB:
+        return vk::ImageAspectFlagBits::eColor;
+    case PixelFormat::Depth32Float:
+        return vk::ImageAspectFlagBits::eDepth;
+    default:
+        throw std::runtime_error("not implemented");
+    }
 }
 
 constexpr vk::SamplerAddressMode toVkSamplerAddressMode(SamplerAddressMode mode)

--- a/src/Vulkan/VulkanTexture.cpp
+++ b/src/Vulkan/VulkanTexture.cpp
@@ -32,7 +32,7 @@ VulkanTexture::VulkanTexture(const VulkanDevice* device, vk::Image&& vkImage, co
       m_vkImage(std::move(vkImage))
 {
     m_subresourceRange = vk::ImageSubresourceRange{}
-          .setAspectMask(toVkImageAspectFlags(desc.usages))
+          .setAspectMask(toVkImageAspectFlags(desc.pixelFormat))
           .setBaseMipLevel(0)
           .setLevelCount(1)
           .setBaseArrayLayer(0)
@@ -85,7 +85,7 @@ VulkanTexture::VulkanTexture(const VulkanDevice* device, const Texture::Descript
     m_vkImage = std::exchange(image, VK_NULL_HANDLE);
 
     m_subresourceRange = vk::ImageSubresourceRange{}
-        .setAspectMask(toVkImageAspectFlags(desc.usages))
+        .setAspectMask(toVkImageAspectFlags(desc.pixelFormat))
         .setBaseMipLevel(0)
         .setLevelCount(1)
         .setBaseArrayLayer(0)

--- a/tests/test_descriptor_operator.cpp
+++ b/tests/test_descriptor_operator.cpp
@@ -9,6 +9,7 @@
 #include "Graphics/Buffer.hpp"
 #include "Graphics/Device.hpp"
 #include "Graphics/Enums.hpp"
+#include "Graphics/Framebuffer.hpp"
 #include "Graphics/GraphicsPipeline.hpp"
 #include "Graphics/Instance.hpp"
 #include "Graphics/ParameterBlockLayout.hpp"
@@ -20,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <map>
+#include <variant>
 
 namespace gfx_test
 {
@@ -63,6 +65,26 @@ TEST(descriptor_operator, texture_descriptor)
     rhs.width = 32;
 
     expectDescriptorComparableInMap(lhs, rhs);
+}
+
+TEST(clear_value, default_value_is_zero_float_color)
+{
+    gfx::ClearValue clearValue {};
+
+    const auto* clearColor = std::get_if<gfx::ClearFloatColor>(&clearValue.value);
+    ASSERT_NE(clearColor, nullptr);
+
+    EXPECT_EQ(clearColor->value, (std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f}));
+}
+
+TEST(clear_value, uint64_packs_low_and_high_bits)
+{
+    gfx::ClearValue clearValue = gfx::ClearValue::uint64(0x0123456789abcdef);
+
+    const auto* clearColor = std::get_if<gfx::ClearUIntColor>(&clearValue.value);
+    ASSERT_NE(clearColor, nullptr);
+
+    EXPECT_EQ(clearColor->value, (std::array<uint32_t, 4>{0x89abcdef, 0x01234567, 0, 0}));
 }
 
 TEST(descriptor_operator, sampler_descriptor)


### PR DESCRIPTION
- **Add texture-to-buffer blits**
- **small format change**
- **Add RG32Uint pixel format mappings**
- **Tidy attachment loop formatting**
- **Track Metal color attachment textures**
- **Add typed framebuffer clear values**
- **Simplify color clear value conversion**
