### PR TITLE
Fix Vulkan host-visible buffer access flags

### DIFF
--- a/src/Vulkan/VulkanBuffer.cpp
+++ b/src/Vulkan/VulkanBuffer.cpp
@@ -27,7 +27,10 @@ VulkanBuffer::VulkanBuffer(const VulkanDevice* device, const Buffer::Descriptor&
 
     VmaAllocationCreateInfo allocInfo = { .usage = VMA_MEMORY_USAGE_AUTO, };
     if (m_storageMode == ResourceStorageMode::hostVisible)
+    {
         allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        allocInfo.requiredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    }
 
     VkBuffer buffer = VK_NULL_HANDLE;
     vmaCreateBuffer(m_device->allocator(), &bufferCreateInfo, &allocInfo, &buffer, &m_allocation, &m_allocInfo);

--- a/src/Vulkan/VulkanBuffer.cpp
+++ b/src/Vulkan/VulkanBuffer.cpp
@@ -28,7 +28,12 @@ VulkanBuffer::VulkanBuffer(const VulkanDevice* device, const Buffer::Descriptor&
     VmaAllocationCreateInfo allocInfo = { .usage = VMA_MEMORY_USAGE_AUTO, };
     if (m_storageMode == ResourceStorageMode::hostVisible)
     {
-        allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        const bool needsCpuRead = static_cast<bool>(m_usages & BufferUsage::copyDestination);
+        // hostVisible + copyDestination is this API's readback convention; use RANDOM for CPU reads.
+        // Other host-visible buffers are upload-style sequential CPU writes.
+        // Revisit this if a future CPU-readable buffer pattern does not include copyDestination.
+        allocInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT |
+            (needsCpuRead ? VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT : VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT);
         allocInfo.requiredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     }
 


### PR DESCRIPTION
## Summary

- require host-coherent memory for mapped Vulkan buffers
- use random host access for readback buffers while keeping sequential host access for upload buffers
- preserve persistent mapping for host-visible allocations

## Why

Host-visible buffers used as copy destinations are read back by the CPU. VMA's sequential-write host access flag does not describe that access pattern and may select unsuitable memory behavior. The allocation now distinguishes readback buffers from upload buffers and explicitly requires coherent mapped memory.

## Impact

Vulkan readback buffers use the VMA random-access allocation path, while ordinary host-visible upload buffers retain the sequential-write path. The public API is unchanged.

## Validation

- `cmake --build build.nosync` (`ninja: no work to do`)
- `git diff --check origin/master...HEAD`
